### PR TITLE
Chore/#9 github auto-assign을 추가합니다.

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,18 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - Zero-1016
+  - sohyun215
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip


### PR DESCRIPTION
## What is this PR? :mag:

승민님의 피드백을 참고하여 Reviewr 자동 등록을 추가합니다.

아래 봇을 추가해두었습니다!

https://github.com/apps/auto-assign

## Changes :memo:

yml 코드를 해석하면 다음과 같습니다.

```yml
# Set to true to add reviewers to pull requests
addReviewers: true

# Set to true to add assignees to pull requests
addAssignees: author

# A list of reviewers to be added to pull requests (GitHub user name)
reviewers:
  - Zero-1016
  - sohyun215

# A number of reviewers added to the pull request
# Set 0 to add all the reviewers (default: 0)
numberOfReviewers: 0

# A list of keywords to be skipped the process that add reviewers if pull requests include it
skipKeywords:
  - wip
```

`addReviewers: true`

풀 리퀘스트에 리뷰어를 자동으로 추가하는 기능을 활성화합니다. true로 설정하면, 새로운 풀 리퀘스트가 생성될 때 지정된 리뷰어들이 자동으로 할당됩니다.

`addAssignees: author`

풀 리퀘스트에 할당할 사람을 지정합니다. author로 설정하면, 풀 리퀘스트 작성자가 자동으로 담당자로 추가됩니다.

`reviewers`

풀 리퀘스트에 자동으로 들어갈 사용자 목록입니다. 저희 각각 넣어두었습니다.

`numberOfReviewers: 0`

각 풀 리퀘스트에 추가할 리뷰어의 수를 정의합니다. 0으로 설정하면, 지정된 모든 리뷰어들이 풀 리퀘스트에 추가됩니다.

`skipKeywords`

풀 리퀘스트 제목이나 설명에 정의해둔 키워드(wip)가 포함되어 있으면 리뷰어 추가 프로세스를 건너뜁니다. 이는 아직 리뷰 준비가 되지 않은 초안 상태의 풀 리퀘스트에 유용합니다.

## Screenshot :camera:

![image](https://github.com/user-attachments/assets/df8a4e5b-1a7d-4498-83a6-8d8fe5f854c8)
