### PR TITLE
Feat/#41 Image Picker를 활용한 이미지 등록을 추가합니다.

### DIFF
--- a/app.json
+++ b/app.json
@@ -39,6 +39,12 @@
             "assets/fonts/Pretendard-Reqular.otf"
           ]
         }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "$(PRODUCT_NAME) 에서 사진 접근 권한을 승인합니다."
+        }
       ]
     ],
     "experiments": {

--- a/app/(app)/project/create.tsx
+++ b/app/(app)/project/create.tsx
@@ -1,21 +1,22 @@
-import { SafeAreaView } from 'react-native';
+import { ScrollView } from 'react-native';
 
-import Typography from '@/components/common/typography';
+import ProjectRegisterForm from '@/components/project/ProjectRegisterForm';
 import { useTabBarEffect } from '@/hooks';
 import { color } from '@/styles/theme';
 import { getSize } from '@/utils';
 
 function Create() {
   useTabBarEffect();
+
   return (
-    <SafeAreaView
+    <ScrollView
       style={{
         flex: 1,
         backgroundColor: color.Background.Alternative,
         height: getSize.screenHeight,
       }}>
-      <Typography>프로젝트 생성</Typography>
-    </SafeAreaView>
+      <ProjectRegisterForm />
+    </ScrollView>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expo": "~51.0.21",
     "expo-constants": "~16.0.2",
     "expo-font": "~12.0.9",
+    "expo-image-picker": "~15.0.7",
     "expo-linear-gradient": "~13.0.2",
     "expo-linking": "~6.3.1",
     "expo-router": "~3.5.18",

--- a/src/components/common/date-input/index.tsx
+++ b/src/components/common/date-input/index.tsx
@@ -1,0 +1,25 @@
+import { AntDesign } from '@expo/vector-icons';
+
+import Typography from '@/components/common/typography';
+
+import * as S from './style';
+
+type Props = {
+  onChange?: () => void;
+  date?: string;
+};
+
+function DateInput({ onChange, date }: Props) {
+  return (
+    <S.Container onPress={onChange}>
+      <AntDesign
+        name='calendar'
+        size={24}
+        color='#979797'
+      />
+      <Typography>{date}</Typography>
+    </S.Container>
+  );
+}
+
+export default DateInput;

--- a/src/components/common/date-input/style.ts
+++ b/src/components/common/date-input/style.ts
@@ -1,0 +1,9 @@
+import styled from '@emotion/native';
+
+import { flexItemCenter } from '@/styles/common';
+
+export const Container = styled.Pressable`
+  ${flexItemCenter};
+  padding: 18px 16px;
+  border-radius: 8px;
+`;

--- a/src/components/common/image-input/index.tsx
+++ b/src/components/common/image-input/index.tsx
@@ -1,0 +1,24 @@
+import { AntDesign } from '@expo/vector-icons';
+
+import { color } from '@/styles/theme';
+
+import * as S from './style';
+
+type Props = {
+  onChange: () => void;
+};
+
+function ImageInput({ onChange }: Props) {
+  return (
+    <S.Container onPress={onChange}>
+      <AntDesign
+        style={{ textAlign: 'center', lineHeight: 24 }}
+        name='plus'
+        size={24}
+        color={color.Label.Alternative}
+      />
+    </S.Container>
+  );
+}
+
+export default ImageInput;

--- a/src/components/common/image-input/style.ts
+++ b/src/components/common/image-input/style.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/native';
+
+import { flexDirectionColumnItemsCenter } from '@/styles/common';
+
+export const Container = styled.Pressable`
+  ${flexDirectionColumnItemsCenter};
+  width: 66px;
+  height: 60px;
+  padding: 18px 21px;
+  background: ${({ theme }) => theme.color.Background.Normal};
+  border-radius: 8px;
+`;

--- a/src/components/common/preview-image/index.tsx
+++ b/src/components/common/preview-image/index.tsx
@@ -1,0 +1,21 @@
+import * as S from './style';
+
+type Props = {
+  images: string[];
+};
+
+function PreviewImage({ images }: Props) {
+  return (
+    <S.Container>
+      {images.map((image, index) => (
+        <S.Image
+          resizeMode='cover'
+          key={index}
+          source={{ uri: image }}
+        />
+      ))}
+    </S.Container>
+  );
+}
+
+export default PreviewImage;

--- a/src/components/common/preview-image/style.ts
+++ b/src/components/common/preview-image/style.ts
@@ -1,0 +1,14 @@
+import styled from '@emotion/native';
+
+import { flexDirectionRow } from '@/styles/common';
+
+export const Container = styled.View`
+  ${flexDirectionRow};
+`;
+
+export const Image = styled.Image`
+  width: 66px;
+  height: 60px;
+  background: ${({ theme }) => theme.color.Background.Normal};
+  border-radius: 8px;
+`;

--- a/src/components/project/ProjectInviteModal/ProjectInviteModal.style.ts
+++ b/src/components/project/ProjectInviteModal/ProjectInviteModal.style.ts
@@ -1,11 +1,20 @@
-import styled from '@emotion/native';
+import styled, { css } from '@emotion/native';
+import { Platform } from 'react-native';
 
+import { SCREEN_SIZE } from '@/constants';
 import { flexDirectionColumn, flexDirectionColumnItemsCenter } from '@/styles/common';
 import { color } from '@/styles/theme';
 import { getSize } from '@/utils';
 
+const WebContainerStyle = css`
+  max-width: ${SCREEN_SIZE.Web + 'px'};
+  padding: 20px;
+  margin: 0 auto;
+`;
+
 export const Container = styled.View`
   ${flexDirectionColumnItemsCenter};
+  ${Platform.OS === 'web' && WebContainerStyle}
   flex: 1;
   background: ${color.Background.Alternative};
 `;

--- a/src/components/project/ProjectRegisterForm/index.tsx
+++ b/src/components/project/ProjectRegisterForm/index.tsx
@@ -1,0 +1,97 @@
+import { launchImageLibraryAsync, MediaTypeOptions } from 'expo-image-picker';
+import { useState } from 'react';
+
+import SolidButton from '@/components/common/button/SolidButton';
+import DateInput from '@/components/common/date-input';
+import ImageInput from '@/components/common/image-input';
+import InputField from '@/components/common/input-field';
+import PreviewImage from '@/components/common/preview-image';
+import Typography from '@/components/common/typography';
+import { color } from '@/styles/theme';
+
+import * as S from './style';
+
+function ProjectRegisterForm() {
+  const [image, setImage] = useState<string | null>(null);
+
+  const pickImage = async () => {
+    const result = await launchImageLibraryAsync({
+      mediaTypes: MediaTypeOptions.Images,
+      allowsEditing: true,
+      aspect: [4, 4],
+      quality: 1,
+    });
+
+    if (!result.canceled) {
+      setImage(result.assets[0].uri);
+    }
+  };
+
+  return (
+    <S.Container>
+      <S.Form>
+        <S.InputContainer>
+          <Typography
+            variant='Body1/Normal'
+            fontWeight='semiBold'
+            color={color.Label.Normal}>
+            프로젝트 이름
+          </Typography>
+          <InputField placeholder='프로젝트의 이름을 적어주세요' />
+        </S.InputContainer>
+        <S.InputContainer>
+          <Typography
+            variant='Body1/Normal'
+            fontWeight='semiBold'
+            color={color.Label.Normal}>
+            프로젝트 정보
+          </Typography>
+          <InputField placeholder='어떤 프로젝트인가요?' />
+        </S.InputContainer>
+        <S.InputContainer>
+          <Typography
+            variant='Body1/Normal'
+            fontWeight='semiBold'
+            color={color.Label.Normal}>
+            프로젝트 이미지
+          </Typography>
+          <S.ImageBox>
+            <ImageInput onChange={pickImage} />
+            <PreviewImage images={image ? [image] : []} />
+          </S.ImageBox>
+        </S.InputContainer>
+        <S.InputContainer>
+          <Typography
+            variant='Body1/Normal'
+            fontWeight='semiBold'
+            color={color.Label.Normal}>
+            기간
+          </Typography>
+          <S.DatePickerBox>
+            <DateInput />
+            <S.DateSplitText>-</S.DateSplitText>
+            <DateInput />
+          </S.DatePickerBox>
+        </S.InputContainer>
+        <S.InputContainer>
+          <Typography
+            variant='Body1/Normal'
+            fontWeight='semiBold'
+            color={color.Label.Normal}>
+            프로젝트 링크
+          </Typography>
+          <InputField placeholder='링크를 입력해주세요' />
+        </S.InputContainer>
+      </S.Form>
+      <S.SubmitButtonBox>
+        <SolidButton
+          full
+          size='large'>
+          다음
+        </SolidButton>
+      </S.SubmitButtonBox>
+    </S.Container>
+  );
+}
+
+export default ProjectRegisterForm;

--- a/src/components/project/ProjectRegisterForm/style.ts
+++ b/src/components/project/ProjectRegisterForm/style.ts
@@ -1,0 +1,40 @@
+import styled from '@emotion/native';
+
+import { flexDirectionColumn, flexDirectionRow } from '@/styles/common';
+
+export const Container = styled.View`
+  ${flexDirectionColumn};
+  gap: 20px;
+  padding: 20px;
+`;
+
+export const Form = styled.View`
+  ${flexDirectionColumn};
+  gap: 36px;
+`;
+
+export const InputContainer = styled.View`
+  ${flexDirectionColumn};
+  gap: 8px;
+`;
+
+export const ImageBox = styled.View`
+  ${flexDirectionRow};
+  gap: 8px;
+`;
+
+export const DatePickerBox = styled.View`
+  ${flexDirectionRow};
+  gap: 8px;
+`;
+
+export const DateSplitText = styled.Text`
+  font-family: Pretendard, serif;
+  font-size: 24px;
+  line-height: 29px;
+  color: ${({ theme }) => theme.color.Label.Normal};
+`;
+
+export const SubmitButtonBox = styled.View`
+  padding: 12px 0 52px;
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9212,6 +9212,7 @@ __metadata:
     expo: "npm:~51.0.21"
     expo-constants: "npm:~16.0.2"
     expo-font: "npm:~12.0.9"
+    expo-image-picker: "npm:~15.0.7"
     expo-linear-gradient: "npm:~13.0.2"
     expo-linking: "npm:~6.3.1"
     expo-router: "npm:~3.5.18"
@@ -10396,6 +10397,26 @@ __metadata:
   peerDependencies:
     expo: "*"
   checksum: 10c0/9c7b63b3a3ee89bfcdbc1704451019b956b451208f0eca3bb1e57b53dd5dcdfb4d080d423583b92f864889a2a5d7624985c0e5103c54b36b8daf813471696b41
+  languageName: node
+  linkType: hard
+
+"expo-image-loader@npm:~4.7.0":
+  version: 4.7.0
+  resolution: "expo-image-loader@npm:4.7.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/7db9df154f1b44e9877361e0707715503eaaf2b18968b6aecb6b0205612cf40bfd99ab8c6e6d7de3a5abd35267e9636963d5050e082af063d8e527763d597eb1
+  languageName: node
+  linkType: hard
+
+"expo-image-picker@npm:~15.0.7":
+  version: 15.0.7
+  resolution: "expo-image-picker@npm:15.0.7"
+  dependencies:
+    expo-image-loader: "npm:~4.7.0"
+  peerDependencies:
+    expo: "*"
+  checksum: 10c0/b8869732fa68e907f8da14038f10477bbbb098f3b144d857e9677c59a3557841bb7beac3dcf3b27896c3223d7723e8a83ffcd3d7376ba1d016ee8c9a76096e46
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What is this PR? :mag:

- [feat: image-picker를 이용한 프로젝트 이미지 등록을 추가합니다.](https://github.com/dnd-side-project/dnd-11th-9-frontend/pull/53/commits/22d300440f8ed5916f27c5e59ba4df904baa7879)

## Changes :memo:

- [feat: web용 모달 스타일을 추가한다.](https://github.com/dnd-side-project/dnd-11th-9-frontend/pull/53/commits/55b18b27244c8ba4ea4701be8bcc319257469b2c)

기존에 web에서 실행할 경우 화면 전체를 감싸는 width 100% 크기의 모달 백그라운드 크기를 웹에서의 너비에 맞춰 보이게 설정하였습니다.