### PR TITLE
Feat/#41 프로젝트 상세페이지를 추가합니다.

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -13,6 +13,7 @@ import { SITE_URLS } from '@/constants';
 import { useSession } from '@/store';
 import { useOnboarding } from '@/store/useOnboarding';
 import useTabBar from '@/store/useTabBar';
+import { color } from '@/styles/theme';
 
 const tabBarOptions = {
   [MAIN_NAVIGATIONS.HOME]: {
@@ -135,7 +136,11 @@ export default function Layout() {
   return (
     <Tabs
       screenOptions={{
+        headerShadowVisible: false,
         headerShown: false,
+        headerStyle: {
+          backgroundColor: color.Background.Alternative,
+        },
       }}
       tabBar={(tabBar) => <TabBar {...tabBar} />}>
       <Tabs.Screen name={MAIN_NAVIGATIONS.PROJECT} />

--- a/app/(app)/project/_layout.tsx
+++ b/app/(app)/project/_layout.tsx
@@ -5,7 +5,7 @@ import { Platform, Pressable } from 'react-native';
 import { PROJECT_NAVIGATIONS } from '@/constants';
 import { color } from '@/styles/theme';
 
-import * as S from './layout.style';
+import * as S from './style';
 
 function Layout() {
   const router = useRouter();
@@ -24,7 +24,6 @@ function Layout() {
         name={PROJECT_NAVIGATIONS.HOME}
         options={{
           title: '프로젝트',
-          headerLeft: () => null,
           headerRight: () => (
             <S.ButtonGroup>
               <Pressable>
@@ -51,14 +50,12 @@ function Layout() {
           animation: 'flip',
           title: '프로젝트 등록',
           headerLeft: ({ canGoBack }) => (
-            <S.ButtonGroup>
-              <Pressable onPress={() => (canGoBack ? router.back() : router.push('/project'))}>
-                <Feather
-                  name='chevron-left'
-                  size={24}
-                />
-              </Pressable>
-            </S.ButtonGroup>
+            <Pressable onPress={() => (canGoBack ? router.back() : router.push('/project'))}>
+              <Feather
+                name='chevron-left'
+                size={24}
+              />
+            </Pressable>
           ),
         }}
       />

--- a/app/(app)/project/create.tsx
+++ b/app/(app)/project/create.tsx
@@ -29,6 +29,8 @@ function Create() {
   const [image, setImage] = useState<string | null>(null);
   const [startDate, setStartDate] = useState<Date>(() => new Date());
   const [endDate, setEndDate] = useState<Date>(() => new Date());
+  const [startDateTouched, setStartDateTouched] = useState(false);
+  const [endDateTouched, setEndDateTouched] = useState(false);
   const [selectUserList, setSelectUserList] = useState<User[]>([]);
 
   const [selectDate, setSelectDate] = useState<'start' | 'end'>('start');
@@ -160,21 +162,33 @@ function Create() {
               </S.ImageBox>
             </S.InputContainer>
             <S.InputContainer>
-              <Typography
-                variant='Body1/Normal'
-                fontWeight='semiBold'
-                color={color.Label.Normal}>
-                기간
-              </Typography>
+              <S.RequiredTitleBox>
+                <Typography
+                  variant='Body1/Normal'
+                  fontWeight='semiBold'
+                  color={color.Label.Normal}>
+                  기간
+                </Typography>
+                <Typography
+                  variant='Body1/Normal'
+                  fontWeight='semiBold'
+                  color={color.Status.Error}>
+                  *
+                </Typography>
+              </S.RequiredTitleBox>
               <S.DatePickerBox>
                 <DateInput
                   date={startDate}
+                  touched={startDateTouched}
                   onPress={() => startDateOpen('start')}
+                  onTouchEnd={() => setStartDateTouched(true)}
                 />
                 <S.DateSplitText>-</S.DateSplitText>
                 <DateInput
                   date={endDate}
+                  touched={endDateTouched}
                   onPress={() => startDateOpen('end')}
+                  onTouchEnd={() => setEndDateTouched(true)}
                 />
               </S.DatePickerBox>
             </S.InputContainer>

--- a/app/(app)/project/detail/[id]/index.tsx
+++ b/app/(app)/project/detail/[id]/index.tsx
@@ -1,0 +1,55 @@
+import { Feather } from '@expo/vector-icons';
+import { useNavigation, useRouter } from 'expo-router';
+import { useLayoutEffect } from 'react';
+import { Platform, Pressable } from 'react-native';
+
+import { MOCK_PROJECT_DETAIL } from '@/__mock__/project';
+import Typography from '@/components/common/typography';
+import ProjectDetail from '@/components/project/ProjectDetail';
+import { color } from '@/styles/theme';
+
+function Page() {
+  const router = useRouter();
+  // const { id } = useLocalSearchParams(); 실제 데이터로 올 경우 해당 id를 이용하여 조회
+  const navigation = useNavigation();
+  const data = MOCK_PROJECT_DETAIL;
+
+  useLayoutEffect(() => {
+    navigation.setOptions({
+      headerStyle: {
+        paddingTop: 12,
+      },
+      headerTitle: data.name,
+      headerTintColor: color.Label.Normal,
+      headerTitleStyle: {
+        fontWeight: 600,
+        fontFamily: 'Pretendard-SemiBold',
+        fontSize: 18,
+        lineHeight: 26,
+      },
+      headerLeft: () => (
+        <Pressable onPress={router.back}>
+          <Feather
+            name='chevron-left'
+            size={24}
+          />
+        </Pressable>
+      ),
+      headerRight: () =>
+        Platform.OS !== 'web' ? (
+          <Pressable onPress={() => router.push('/project/create')}>
+            <Typography
+              variant='Body1/Normal'
+              fontWeight='medium'
+              color={color.Label.Alternative}>
+              편집
+            </Typography>
+          </Pressable>
+        ) : null,
+    });
+  }, [navigation]);
+
+  return <ProjectDetail data={data} />;
+}
+
+export default Page;

--- a/app/(app)/project/detail/[id]/style.ts
+++ b/app/(app)/project/detail/[id]/style.ts
@@ -1,0 +1,5 @@
+import styled from '@emotion/native';
+
+export const Container = styled.SafeAreaView`
+  padding: 32px 20px 52px;
+`;

--- a/app/(app)/project/index.tsx
+++ b/app/(app)/project/index.tsx
@@ -1,18 +1,16 @@
 import { useLayoutEffect, useState } from 'react';
 import { SafeAreaView } from 'react-native';
 
+import { MOCK_PROJECT_ITEM, MOCK_PROJECT_LIST } from '@/__mock__/project';
 import ProjectInviteModal from '@/components/project/ProjectInviteModal';
 import ProjectList from '@/components/project/ProjectList';
 import { color } from '@/styles/theme';
 
+const inviteData = MOCK_PROJECT_ITEM;
+const data = MOCK_PROJECT_LIST;
+
 function Project() {
   const [visible, setVisible] = useState(false);
-
-  const data = {
-    project_name: '위프로',
-    project_profile: 'https://picsum.photos/200',
-    member_length: 6,
-  };
 
   const onRequestClose = () => {
     setVisible(false);
@@ -22,91 +20,16 @@ function Project() {
     setVisible(true);
   }, []);
 
-  const mockList = [
-    {
-      id: 1,
-      name: '위프로',
-      profile: 'https://picsum.photos/200',
-      member_num: 6,
-    },
-    {
-      id: 2,
-      name: '후피',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-    {
-      id: 3,
-      name: 'Code Red',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-    {
-      id: 4,
-      name: 'Veco',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-    {
-      id: 5,
-      name: '위프로',
-      profile: 'https://picsum.photos/200',
-      member_num: 6,
-    },
-    {
-      id: 6,
-      name: '후피',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-    {
-      id: 7,
-      name: 'Code Red',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-    {
-      id: 8,
-      name: 'Veco',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-    {
-      id: 9,
-      name: '위프로',
-      profile: 'https://picsum.photos/200',
-      member_num: 6,
-    },
-    {
-      id: 10,
-      name: '후피',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-    {
-      id: 11,
-      name: 'Code Red',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-    {
-      id: 12,
-      name: 'Last Project',
-      profile: 'https://picsum.photos/200',
-      member_num: 3,
-    },
-  ];
-
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: color.Background.Alternative }}>
       <ProjectInviteModal
-        project_name={data.project_name}
-        project_profile={data.project_profile}
-        member_length={data.member_length}
+        project_name={inviteData.name}
+        project_profile={inviteData.profile}
+        member_length={inviteData.member_num}
         visible={visible}
         onRequestClose={onRequestClose}
       />
-      <ProjectList data={mockList} />
+      <ProjectList data={data} />
     </SafeAreaView>
   );
 }

--- a/app/(app)/project/style.ts
+++ b/app/(app)/project/style.ts
@@ -5,5 +5,4 @@ import { flexDirectionRow } from '@/styles/common';
 export const ButtonGroup = styled.View`
   ${flexDirectionRow};
   gap: 10px;
-  padding: 20px 20px 8px;
 `;

--- a/src/__mock__/project/index.ts
+++ b/src/__mock__/project/index.ts
@@ -1,3 +1,4 @@
+import type { ProjectDetailType } from '@/components/project/ProjectDetail';
 import type { ProjectItemType } from '@/components/project/ProjectList';
 
 export const MOCK_PROJECT_ITEM: ProjectItemType = {
@@ -45,3 +46,40 @@ export const MOCK_PROJECT_LIST: ProjectItemType[] = [
     member_num: 3,
   },
 ] as const;
+
+export const MOCK_PROJECT_DETAIL: ProjectDetailType = {
+  id: 1,
+  name: '위프로',
+  description: '팀원이 만들어주는 명함 서비스',
+  profile: 'https://picsum.photos/200',
+  startDate: '24.07.01',
+  endDate: '24.09.30',
+  review_count: 4,
+  userList: [
+    {
+      id: 1,
+      name: '이지형',
+    },
+    {
+      id: 2,
+      name: '이예지',
+    },
+    {
+      id: 3,
+      name: '양의진',
+    },
+    {
+      id: 4,
+      name: '조민제',
+    },
+    {
+      id: 5,
+      name: '김소현',
+    },
+    {
+      id: 6,
+      name: '김희진',
+    },
+  ],
+  link: 'https://www.naver.com',
+} as const;

--- a/src/components/common/date-input/index.tsx
+++ b/src/components/common/date-input/index.tsx
@@ -3,27 +3,33 @@ import dayjs from 'dayjs';
 
 import Typography from '@/components/common/typography';
 import { shadow } from '@/styles/shadow';
+import { color } from '@/styles/theme';
 
 import * as S from './style';
 
 type Props = {
   date: Date;
+  touched: boolean;
   onPress: () => void;
+  onTouchEnd: () => void;
 };
 
-function DateInput({ onPress, date }: Props) {
+function DateInput({ touched, onPress, onTouchEnd, date }: Props) {
   return (
     <S.Container
       style={shadow[2]}
-      onPress={onPress}>
+      onPress={onPress}
+      onTouchEnd={onTouchEnd}>
       <S.IconBox>
         <AntDesign
           name='calendar'
           size={20}
-          color='#979797'
+          color={touched ? color.Label.Normal : '#979797'}
         />
       </S.IconBox>
-      <Typography>{dayjs(date).format('YYYY-MM-DD')}</Typography>
+      <Typography color={touched ? color.Label.Normal : '#979797'}>
+        {dayjs(date).format('YYYY-MM-DD')}
+      </Typography>
     </S.Container>
   );
 }

--- a/src/components/project/ProjectDetail/ProjectDetail.stories.tsx
+++ b/src/components/project/ProjectDetail/ProjectDetail.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { View } from 'react-native';
+
+import { MOCK_PROJECT_DETAIL } from '@/__mock__/project';
+import { SCREEN_SIZE } from '@/constants';
+
+import ProjectDetail from './';
+
+const ProjectInviteModalMeta: Meta<typeof ProjectDetail> = {
+  title: 'project/ProjectDetail',
+  component: ProjectDetail,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default ProjectInviteModalMeta;
+
+export const Primary: StoryObj<typeof ProjectDetail> = {
+  args: {
+    data: MOCK_PROJECT_DETAIL,
+  },
+  render: (props) => (
+    <View style={{ width: SCREEN_SIZE.WEB_WIDTH, height: SCREEN_SIZE.WEB_HEIGHT }}>
+      <ProjectDetail {...props} />
+    </View>
+  ),
+};

--- a/src/components/project/ProjectDetail/index.tsx
+++ b/src/components/project/ProjectDetail/index.tsx
@@ -1,0 +1,152 @@
+import { AntDesign } from '@expo/vector-icons';
+import { ScrollView } from 'react-native';
+
+import SolidButton from '@/components/common/button/SolidButton';
+import SlideBar from '@/components/common/slide-bar';
+import Typography from '@/components/common/typography';
+import { COMPONENT_SIZE } from '@/constants';
+import { shadow } from '@/styles/shadow';
+import { color } from '@/styles/theme';
+import { getSize } from '@/utils';
+
+import * as S from './style';
+
+export type ProjectDetailType = {
+  id: number;
+  name: string;
+  description: string;
+  profile: string;
+  startDate: string;
+  endDate: string;
+  review_count: number;
+  userList: UserType[];
+  link: string;
+};
+
+type UserType = {
+  id: number;
+  name: string;
+};
+
+type Props = {
+  data: ProjectDetailType;
+};
+
+function ProjectDetail({ data }: Props) {
+  return (
+    <ScrollView
+      style={{
+        marginBottom: COMPONENT_SIZE.BOTTOM_NAV,
+        flex: 1,
+        backgroundColor: color.Background.Alternative,
+        height: getSize.screenHeight,
+      }}>
+      <S.Container>
+        <S.ProjectCard>
+          <S.ProjectImage
+            style={shadow[0]}
+            source={{ uri: data.profile }}
+          />
+          <S.ProjectIntro>
+            <Typography
+              variant='Heading1'
+              fontWeight='semiBold'
+              color={color.Label.Strong}>
+              {data.name}
+            </Typography>
+            <Typography
+              variant='Body1/Normal'
+              fontWeight='medium'
+              color={color.Label.Strong}>
+              {data.description}
+            </Typography>
+          </S.ProjectIntro>
+        </S.ProjectCard>
+
+        <S.ProjectItem>
+          <Typography
+            variant='Body1/Normal'
+            color={color.Label.Neutral}>
+            기간
+          </Typography>
+          <S.DateBox style={shadow[0]}>
+            <AntDesign
+              name='calendar'
+              size={20}
+            />
+            <Typography
+              variant='Body1/Reading'
+              fontWeight='medium'
+              color={color.Label.Strong}>
+              {data.startDate} - {data.endDate}
+            </Typography>
+          </S.DateBox>
+        </S.ProjectItem>
+
+        <S.ProjectItem>
+          <Typography
+            variant='Body1/Normal'
+            color={color.Label.Neutral}>
+            팀원
+          </Typography>
+          <S.ProjectTeamBox>
+            <S.SlideBarContainer style={shadow[0]}>
+              <S.SlideBarBox>
+                <SlideBar
+                  max_value={data.userList.length}
+                  current_value={data.review_count}
+                />
+              </S.SlideBarBox>
+              <S.SlideValueText>
+                <Typography
+                  variant='Caption1'
+                  color={data.review_count === 0 ? color.Label.Assistive : color.Primary.Normal}>
+                  {data.review_count}
+                </Typography>
+                <Typography
+                  variant='Caption1'
+                  color={color.Label.Assistive}>
+                  /{data.userList.length}
+                </Typography>
+              </S.SlideValueText>
+            </S.SlideBarContainer>
+            <S.ProjectUserList>
+              {data.userList.map((user) => (
+                <S.ProjectUser
+                  style={shadow[0]}
+                  key={user.id}>
+                  <Typography
+                    variant='Body1/Reading'
+                    fontWeight='medium'
+                    color={color.Label.Strong}>
+                    {user.name}
+                  </Typography>
+                </S.ProjectUser>
+              ))}
+            </S.ProjectUserList>
+          </S.ProjectTeamBox>
+        </S.ProjectItem>
+
+        <S.ProjectItem>
+          <Typography
+            variant='Body1/Normal'
+            color={color.Label.Neutral}>
+            프로젝트 링크
+          </Typography>
+          <S.LinkBox style={shadow[0]}>
+            <Typography
+              variant='Body1/Reading'
+              fontWeight='medium'
+              color={color.Label.Strong}>
+              {data.link}
+            </Typography>
+          </S.LinkBox>
+        </S.ProjectItem>
+
+        <SolidButton full>설문지 만들기</SolidButton>
+      </S.Container>
+    </ScrollView>
+  );
+}
+
+export default ProjectDetail;

--- a/src/components/project/ProjectDetail/style.ts
+++ b/src/components/project/ProjectDetail/style.ts
@@ -1,12 +1,11 @@
-import styled from '@emotion/native';
-import { Platform } from 'react-native';
+import styled, { css } from '@emotion/native';
 
 import {
   flexDirectionColumn,
   flexDirectionRow,
   flexDirectionRowItemsCenter,
 } from '@/styles/common';
-import { getSize } from '@/utils';
+import { getSize, isMobile } from '@/utils';
 
 export const Container = styled.SafeAreaView`
   ${flexDirectionColumn};
@@ -65,15 +64,27 @@ export const SlideValueText = styled.View`
   ${flexDirectionRow};
 `;
 
-export const ProjectUserList = styled.View`
+const ProjectUserListMobileStyle = css`
   ${flexDirectionRow};
   flex-wrap: wrap;
+`;
+
+const ProjectUserListWebStyle = css`
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+`;
+
+export const ProjectUserList = styled.View`
+  ${isMobile ? ProjectUserListMobileStyle : ProjectUserListWebStyle}
   gap: 8px;
 `;
 
+const ProjectUserItemMobileStyle = css`
+  flex-basis: ${(getSize.screenWidth - 48) / 2 + 'px'};
+`;
+
 export const ProjectUser = styled.View`
-  flex-basis: ${(Platform.OS === 'web' ? getSize.screenWidth - 66 : getSize.screenWidth - 48) / 2 +
-  'px'};
+  ${isMobile ? ProjectUserItemMobileStyle : flexDirectionColumn};
   padding: 18px 16px;
   background: ${({ theme }) => theme.color.Background.Normal};
   border-radius: 8px;

--- a/src/components/project/ProjectDetail/style.ts
+++ b/src/components/project/ProjectDetail/style.ts
@@ -1,0 +1,86 @@
+import styled from '@emotion/native';
+import { Platform } from 'react-native';
+
+import {
+  flexDirectionColumn,
+  flexDirectionRow,
+  flexDirectionRowItemsCenter,
+} from '@/styles/common';
+import { getSize } from '@/utils';
+
+export const Container = styled.SafeAreaView`
+  ${flexDirectionColumn};
+  gap: 24px;
+  padding: 32px 20px 52px;
+`;
+
+export const ProjectCard = styled.View`
+  ${flexDirectionRowItemsCenter};
+  gap: 12px;
+`;
+
+export const ProjectImage = styled.Image`
+  width: 80px;
+  height: 80px;
+  border-radius: 60px;
+`;
+
+export const ProjectIntro = styled.View`
+  ${flexDirectionColumn};
+`;
+
+export const ProjectItem = styled.View`
+  ${flexDirectionColumn};
+  gap: 8px;
+`;
+
+export const DateBox = styled.View`
+  ${flexDirectionRowItemsCenter};
+  gap: 8px;
+  padding: 16px;
+  background: ${({ theme }) => theme.color.Background.Normal};
+  border-radius: 8px;
+`;
+
+export const ProjectTeamBox = styled.View`
+  ${flexDirectionColumn};
+  gap: 8px;
+`;
+
+export const SlideBarContainer = styled.View`
+  ${flexDirectionRowItemsCenter};
+  gap: 8px;
+  justify-content: space-between;
+  width: 100%;
+  padding: 13px 21px;
+  background: ${({ theme }) => theme.color.Background.Normal};
+  border-radius: 8px;
+`;
+
+export const SlideBarBox = styled.View`
+  flex-grow: 1;
+`;
+
+export const SlideValueText = styled.View`
+  ${flexDirectionRow};
+`;
+
+export const ProjectUserList = styled.View`
+  ${flexDirectionRow};
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+export const ProjectUser = styled.View`
+  flex-basis: ${(Platform.OS === 'web' ? getSize.screenWidth - 66 : getSize.screenWidth - 48) / 2 +
+  'px'};
+  padding: 18px 16px;
+  background: ${({ theme }) => theme.color.Background.Normal};
+  border-radius: 8px;
+`;
+
+export const LinkBox = styled.View`
+  padding: 16px;
+  background: ${({ theme }) => theme.color.Background.Normal};
+  border-radius: 8px;
+`;

--- a/src/components/project/ProjectItem/index.tsx
+++ b/src/components/project/ProjectItem/index.tsx
@@ -1,3 +1,5 @@
+import { useRouter } from 'expo-router';
+
 import SlideBar from '@/components/common/slide-bar';
 import Typography from '@/components/common/typography';
 import ProjectImage from '@/components/project/ProjectImage';
@@ -6,9 +8,12 @@ import { color } from '@/styles/theme';
 
 import * as S from './style';
 
-function ProjectItem({ name, member_num, profile, review_count }: ProjectItemType) {
+function ProjectItem({ name, member_num, profile, review_count, id }: ProjectItemType) {
+  const router = useRouter();
+
   return (
-    <S.Container>
+    <S.Container
+      onLongPress={() => router.push({ pathname: '/project/detail/[id]', params: { id } })}>
       <ProjectImage uri={profile} />
       <S.ProjectStatusBox>
         <Typography

--- a/src/components/project/ProjectItem/style.ts
+++ b/src/components/project/ProjectItem/style.ts
@@ -2,7 +2,7 @@ import styled from '@emotion/native';
 
 import { flexDirectionColumn, flexDirectionRowItemsCenter } from '@/styles/common';
 
-export const Container = styled.View`
+export const Container = styled.Pressable`
   ${flexDirectionRowItemsCenter};
   gap: 10px;
   padding: 16px;


### PR DESCRIPTION
## What is this PR? :mag:
- [feat: 프로젝트 상세페이지를 추가합니다.](https://github.com/dnd-side-project/dnd-11th-9-frontend/commit/7edf436a1f2b1806c1cde699bfb65a86e6180ecd)

## Changes :memo:

### 프로젝트 상세페이지를 추가하였습니다.

현재 길게 누를 경우 `onLongPress`할 경우 상세페이지로 이동됩니다.

두 줄로 갈라져야 하는 부분에서 width 값을 가져오는 getSize를 사용하였지만, scroll이 생기고 안 생길 경우 차이가 생길 것 같아 web과 mobile 각각 다른 스타일을 준비해 두었습니다.

## Screenshot :camera:
![image](https://github.com/user-attachments/assets/1e6eeaeb-ea95-44c9-8f4b-a1028381a4dc)
