### PR TITLE
Fix/#81 root layout navigation error

### DIFF
--- a/app/(beforeLogin)/oauth2/authorization/login.tsx
+++ b/app/(beforeLogin)/oauth2/authorization/login.tsx
@@ -1,24 +1,42 @@
 import styled from '@emotion/native';
 import { useRoute } from '@react-navigation/core';
-import React, { useEffect } from 'react';
+import { useRouter } from 'expo-router';
+import React, { useEffect, useState } from 'react';
 import { ActivityIndicator } from 'react-native';
 
 import { useSession } from '@/store';
+import { flexDirectionColumnItemsCenter } from '@/styles/common';
 import { setHeader } from '@/utils';
 
 function Login() {
+  const [loading, setLoading] = useState(true);
   const route = useRoute();
+  const router = useRouter();
   const { signIn } = useSession();
 
   const { token, refresh } = route.params as { token?: string; refresh?: string };
 
-  useEffect(() => {
-    if (typeof token === 'string' && typeof refresh === 'string') {
-      setHeader('Authorization', `Bearer ${token}`);
-      signIn(refresh);
-    }
-    // ts-expect-error signIn을 넣을 경우 무한 재 렌더링을 하게 됩니다.
-  }, [refresh, token]);
+  useEffect(
+    function setToken() {
+      if (typeof token === 'string' && typeof refresh === 'string') {
+        setHeader('Authorization', `Bearer ${token}`);
+        signIn(refresh);
+      }
+
+      setLoading(false);
+      // ts-expect-error signIn을 넣을 경우 무한 재 렌더링을 하게 됩니다.
+    },
+    [refresh, token]
+  );
+
+  useEffect(
+    function isNotLoadRedirect() {
+      if (!loading) {
+        router.replace('/');
+      }
+    },
+    [loading, router]
+  );
 
   return (
     <S.Container>
@@ -32,6 +50,7 @@ function Login() {
 
 const S = {
   Container: styled.SafeAreaView`
+    ${flexDirectionColumnItemsCenter};
     flex: 1;
   `,
 };

--- a/app/(beforeLogin)/sign-in.tsx
+++ b/app/(beforeLogin)/sign-in.tsx
@@ -16,11 +16,14 @@ import { getSize } from '@/utils';
 function SignIn() {
   const { signIn, refreshToken } = useSession();
 
-  useEffect(() => {
-    if (refreshToken) {
-      signIn();
-    }
-  }, [refreshToken, signIn]);
+  useEffect(
+    function ifHasRefreshTokenGoToMain() {
+      if (refreshToken) {
+        signIn(refreshToken);
+      }
+    },
+    [refreshToken, signIn]
+  );
 
   return (
     <S.LoginWrapper>

--- a/src/components/home/BusinessCard/BusinessCard.stories.tsx
+++ b/src/components/home/BusinessCard/BusinessCard.stories.tsx
@@ -33,12 +33,6 @@ const SkeletonMeta: Meta<typeof BusinessCard> = {
       },
       description: '스크린에 보이는지 여부를 입력해주세요',
     },
-    onboarding: {
-      control: {
-        type: 'boolean',
-      },
-      description: '온보딩 화면인지 여부를 입력해주세요',
-    },
   },
   parameters: {
     layout: 'centered',

--- a/src/store/useSession.tsx
+++ b/src/store/useSession.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'expo-router';
 import { createContext, type PropsWithChildren, useContext } from 'react';
 
 import { STORAGE_KEYS } from '@/constants';
@@ -6,7 +5,7 @@ import { useStorageState } from '@/hooks/useStorageState';
 import { useOnboarding } from '@/store/useOnboarding';
 
 const AuthContext = createContext<{
-  signIn: (refreshToken?: string | null) => void;
+  signIn: (refreshToken: string) => void;
   signOut: () => void;
   refreshToken?: string | null;
   isLoading: boolean;
@@ -33,18 +32,13 @@ export function useSession() {
 
 export function SessionProvider({ children }: PropsWithChildren) {
   const [[isLoading, refreshToken], setSession] = useStorageState(STORAGE_KEYS.SESSION);
-  const router = useRouter();
   const { resetOnBoarding } = useOnboarding();
 
   return (
     <AuthContext.Provider
       value={{
-        signIn: (refreshToken = null) => {
-          if (refreshToken !== null) {
-            router.push('/');
-          }
+        signIn: (refreshToken: string) => {
           setSession(refreshToken);
-          router.push('/');
         },
         signOut: () => {
           setSession(null);


### PR DESCRIPTION
## What is this PR? :mag:
- [fix: navigation error를 수정합니다.](https://github.com/dnd-side-project/dnd-11th-9-frontend/commit/13e50d0b00d0d7ea0199636ca02819de6756ae99)

## Changes :memo:

### navigation error를 수정합니다.

> 네비게이션을 시도할 때 Root Layout이 아직 완전히 준비되지 않았거나, Root Layout 내에서 Slot 또는 다른 네비게이터가 렌더링되지 않은 상태에서 네비게이션을 트리거하기 때문에 발생하는 문제

로딩이 끝났을 때 페이지를 변경하도록 코드를 수정합니다.

```tsx
  useEffect(
    function setToken() {
      if (typeof token === 'string' && typeof refresh === 'string') {
        setHeader('Authorization', `Bearer ${token}`);
        signIn(refresh);
      }

      setLoading(false);
      // ts-expect-error signIn을 넣을 경우 무한 재 렌더링을 하게 됩니다.
    },
    [refresh, token]
  );

  useEffect(
    function isNotLoadRedirect() {
      if (!loading) {
        router.replace('/');
      }
    },
    [loading, router]
  );
```