### PR TITLE
Feat/#2 CustomHeader를 추가합니다.

### DIFF
--- a/src/components/common/custom-header/CustomHeader.stories.tsx
+++ b/src/components/common/custom-header/CustomHeader.stories.tsx
@@ -1,0 +1,97 @@
+import { AntDesign, Feather } from '@expo/vector-icons';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CustomHeader from '@/components/common/custom-header/index';
+import Typography from '@/components/common/typography';
+import { color } from '@/styles/theme';
+
+const CustomHeaderMeta: Meta<typeof CustomHeader> = {
+  title: 'common/CustomHeader',
+  component: CustomHeader,
+  argTypes: {
+    backgroundColor: {
+      control: {
+        type: 'color',
+      },
+      description: '배경색을 설정합니다.',
+    },
+    title: {
+      control: {
+        type: 'text',
+      },
+      description: '헤더 타이틀을 설정합니다.',
+    },
+  },
+};
+
+export default CustomHeaderMeta;
+
+export const Preview1: StoryObj<typeof CustomHeader> = {
+  args: {
+    title: '프로젝트',
+  },
+  render: (args) => {
+    return (
+      <CustomHeader
+        title='프로젝트'
+        left={
+          <CustomHeader.Button onPress={() => console.log('뒤로가기 클릭')}>
+            <Feather
+              name='chevron-left'
+              size={24}
+            />
+          </CustomHeader.Button>
+        }
+        right={
+          <CustomHeader.Button>
+            <Typography
+              variant='Body1/Normal'
+              fontWeight='medium'
+              color={color.Label.Alternative}>
+              편집
+            </Typography>
+          </CustomHeader.Button>
+        }
+        {...args}
+      />
+    );
+  },
+};
+
+export const Preview2: StoryObj<typeof CustomHeader> = {
+  args: {
+    title: '프로젝트',
+    backgroundColor: color.Background.Alternative,
+  },
+  render: (args) => {
+    return (
+      <CustomHeader
+        left={
+          <CustomHeader.Button onPress={() => console.log('뒤로가기 클릭')}>
+            <Feather
+              name='chevron-left'
+              size={24}
+            />
+          </CustomHeader.Button>
+        }
+        right={
+          <CustomHeader.ButtonGroup>
+            <CustomHeader.ButtonGroupItem>
+              <AntDesign
+                name='search1'
+                size={24}
+              />
+            </CustomHeader.ButtonGroupItem>
+            <CustomHeader.ButtonGroupItem>
+              <AntDesign
+                name='plus'
+                size={24}
+              />
+            </CustomHeader.ButtonGroupItem>
+          </CustomHeader.ButtonGroup>
+        }
+        {...args}
+      />
+    );
+  },
+};

--- a/src/components/common/custom-header/index.tsx
+++ b/src/components/common/custom-header/index.tsx
@@ -1,0 +1,66 @@
+import type { ComponentPropsWithoutRef, PropsWithChildren, ReactElement } from 'react';
+import type { PressableProps, ViewProps } from 'react-native';
+import { StatusBar } from 'react-native';
+
+import Typography from '@/components/common/typography';
+import { color } from '@/styles/theme';
+import { isMobile } from '@/utils';
+
+import * as S from './style';
+
+type Props = {
+  title?: string;
+  titleProps?: ComponentPropsWithoutRef<typeof Typography>;
+  left?: ReactElement;
+  right?: ReactElement;
+  backgroundColor?: string;
+} & ViewProps;
+
+function Layout({
+  backgroundColor = color.Background.Normal,
+  title,
+  titleProps,
+  left,
+  right,
+  ...rest
+}: PropsWithChildren<Props>) {
+  return (
+    <S.Layout
+      $backgroundColor={backgroundColor}
+      {...rest}>
+      {isMobile && <StatusBar backgroundColor={backgroundColor} />}
+      {title && (
+        <S.TitleSection>
+          <Typography
+            variant='Headline1'
+            fontWeight='semiBold'
+            {...titleProps}>
+            {title}
+          </Typography>
+        </S.TitleSection>
+      )}
+      {left && <S.LeftSection>{left}</S.LeftSection>}
+      {right && <S.RightSection>{right}</S.RightSection>}
+    </S.Layout>
+  );
+}
+
+function ButtonGroup({ children, ...rest }: PropsWithChildren<ViewProps>) {
+  return <S.ButtonGroupLayout {...rest}>{children}</S.ButtonGroupLayout>;
+}
+
+function ButtonGroupItem({ children, ...rest }: PropsWithChildren<PressableProps>) {
+  return <S.ButtonItem {...rest}>{children}</S.ButtonItem>;
+}
+
+function Button({ children, ...rest }: PropsWithChildren<PressableProps>) {
+  return <S.Button {...rest}>{children}</S.Button>;
+}
+
+const CustomHeader = Object.assign(Layout, {
+  ButtonGroup,
+  ButtonGroupItem,
+  Button,
+});
+
+export default CustomHeader;

--- a/src/components/common/custom-header/style.ts
+++ b/src/components/common/custom-header/style.ts
@@ -1,0 +1,50 @@
+import styled from '@emotion/native';
+
+import { flexDirectionColumnItemsCenter, flexDirectionRowItemsCenter } from '@/styles/common';
+
+export const Layout = styled.View<{ $backgroundColor: string }>`
+  position: relative;
+  width: 100%;
+  height: 40px;
+  background-color: ${({ $backgroundColor }) => $backgroundColor};
+`;
+
+// 버튼을 묶음으로 여러개를 사용할 때 사용하세요
+export const ButtonGroupLayout = styled.View`
+  ${flexDirectionRowItemsCenter};
+  gap: 8px;
+  padding: 8px;
+`;
+
+export const ButtonItem = styled.Pressable`
+  ${flexDirectionColumnItemsCenter};
+  height: 24px;
+  cursor: pointer;
+`;
+
+// 버튼을 하나만 넣을 때 사용하세요
+export const Button = styled(ButtonItem)`
+  padding: 8px;
+`;
+
+export const LeftSection = styled.View`
+  ${flexDirectionColumnItemsCenter};
+  position: absolute;
+  left: 12px;
+  justify-content: center;
+  height: 40px;
+`;
+
+export const RightSection = styled.View`
+  ${flexDirectionColumnItemsCenter};
+  position: absolute;
+  right: 12px;
+  justify-content: center;
+  height: 40px;
+`;
+
+export const TitleSection = styled.View`
+  ${flexDirectionColumnItemsCenter};
+  justify-content: center;
+  height: 40px;
+`;


### PR DESCRIPTION
## What is this PR? :mag:

- [feat: customHeader를 추가합니다.](https://github.com/dnd-side-project/dnd-11th-9-frontend/commit/0ae77225b7d0da0b3c3beaa06a5766d514731011)

## Changes :memo:

### CustomHeader를 추가합니다.

CustomHeader를 추가한 이유는 다음과 같습니다.

1. android 기본 설정으로 인해 화살표가 2개가 보이는 현상 발생 (커스텀 버튼, 기본 버튼 총 2개)
2. navigation을 통해 이동한 경우 불필요한 버튼이 보이는 현상 발생 (이전 폴더 경로가 상단바에 보임)
3. screenOptions을 통해 `height`, `padding-top`등 커스텀을 필요로 하는 부분에 있어 적용을 하는데 복잡하였습니다.

이러한 이유로 인해 기존에 사용하던 options을 안 보이게 설정을 하고 Layout에 최상단에 위치할 생각입니다.

stories 파일을 확인하신다면 예시 파일을 보실 수 있습니다.

## Screenshot :camera:
![image](https://github.com/user-attachments/assets/5e34c5ec-b973-4a24-aec7-2a8d29e896d3)
